### PR TITLE
Fail translation if an invalid level is provided

### DIFF
--- a/label_trans.go
+++ b/label_trans.go
@@ -1,7 +1,10 @@
-// Package setrans provides a mechanism for translating contexts using mcstransd
+// Package setrans provides a mechanism for translating contexts using mcstransd.
 package setrans
 
-import "net"
+import (
+	"errors"
+	"net"
+)
 
 type requestType uint32
 
@@ -9,6 +12,11 @@ const (
 	reqRawToTrans requestType = 2
 	reqTransToRaw requestType = 3
 	reqRawToColor requestType = 4
+)
+
+var (
+	// ErrInvalidLevel is returned if a context cannot be translated because it has an invalid level.
+	ErrInvalidLevel = errors.New("invalid level provided")
 )
 
 type setransMsg struct {

--- a/label_trans_selinux.go
+++ b/label_trans_selinux.go
@@ -94,6 +94,10 @@ func (c *Conn) makeRequest(con string, t requestType) (string, error) {
 	case err := <-c.errch:
 		return "", err
 	case req := <-c.mcstransch:
+		if con == req.label {
+			return "", ErrInvalidLevel
+		}
+
 		return req.label, nil
 	}
 }

--- a/label_trans_selinux_test.go
+++ b/label_trans_selinux_test.go
@@ -39,8 +39,8 @@ func TestTranslation(t *testing.T) {
 			},
 			{
 				orig: "staff_u:staff_r:staff_t:FooLow-FooHigh",
-				want: "staff_u:staff_r:staff_t:FooLow-FooHigh",
-				name: "test an invalid original context to TransToRaw",
+				name: "invalid level not in setrans configuration to TransToRaw should fail",
+				err:  ErrInvalidLevel.Error(),
 			},
 			{
 				orig: "FooLow-FooHigh",
@@ -92,6 +92,11 @@ func TestTranslation(t *testing.T) {
 				orig: "staff_u:staff_r:staff_t:s0-s15:c0.c1023",
 				want: "staff_u:staff_r:staff_t:SystemLow-SystemHigh",
 				name: "test a valid RawToTrans",
+			},
+			{
+				orig: "staff_u:staff_r:staff_t:x0-x15",
+				name: "test invalid level",
+				err:  ErrInvalidLevel.Error(),
 			},
 		}
 


### PR DESCRIPTION
Setrans fails silently by returning the original label if a level cannot
be translated. Instead, go-setrans will now notify users if an error
occurs.
