### PR TITLE
add names to tests

### DIFF
--- a/label_trans_selinux.go
+++ b/label_trans_selinux.go
@@ -34,7 +34,7 @@ func getNativeEndian() (binary.ByteOrder, error) {
 	case [2]byte{0xAB, 0xCD}:
 		return binary.BigEndian, nil
 	default:
-		return nil, fmt.Errorf("Could not determine native endianness.")
+		return nil, fmt.Errorf("could not determine native endianness")
 	}
 }
 

--- a/label_trans_selinux_test.go
+++ b/label_trans_selinux_test.go
@@ -61,8 +61,10 @@ func TestTranslation(t *testing.T) {
 		defer conn.Close()
 
 		for _, tt := range tests {
-			got, err := conn.TransToRaw(tt.orig)
-			check(t, err, tt.err, got, tt.want)
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := conn.TransToRaw(tt.orig)
+				check(t, err, tt.err, got, tt.want)
+			})
 		}
 	})
 
@@ -84,8 +86,10 @@ func TestTranslation(t *testing.T) {
 		defer conn.Close()
 
 		for _, tt := range tests {
-			got, err := conn.RawToColor(tt.orig)
-			check(t, err, tt.err, got, tt.want)
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := conn.RawToColor(tt.orig)
+				check(t, err, tt.err, got, tt.want)
+			})
 		}
 	})
 
@@ -112,8 +116,10 @@ func TestTranslation(t *testing.T) {
 		defer conn.Close()
 
 		for _, tt := range tests {
-			got, err := conn.RawToTrans(tt.orig)
-			check(t, err, tt.err, got, tt.want)
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := conn.RawToTrans(tt.orig)
+				check(t, err, tt.err, got, tt.want)
+			})
 		}
 	})
 }


### PR DESCRIPTION
- Error messages should not be capitalized or end in punctuation
- Display the name of each test being run
